### PR TITLE
Optional root nodes, Template object modification

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -227,10 +227,10 @@ class Collection
         if (!empty($this->queries)) {
             $properties['queries'] = $this->queries;
         }
-        if (!empty($this->template)) {
+        if (!is_null($this->template)) {
             $properties['template'] = $this->template;
         }
-        if (!empty($this->error)) {
+        if (!is_null($this->error)) {
             $properties['error'] = $this->error;
         }
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -216,6 +216,24 @@ class Collection
             'template' => $this->template,
             'error' => $this->error,
         );
+        $properties['version'] = $this->getVersion();
+        $properties['href'] = $this->href;
+        if (!empty($this->links)) {
+            $properties['links'] = $this->links;
+        }
+        if (!empty($this->items)) {
+            $properties['items'] = $this->items;
+        }
+        if (!empty($this->queries)) {
+            $properties['queries'] = $this->queries;
+        }
+        if (!empty($this->template)) {
+            $properties['template'] = $this->template;
+        }
+        if (!empty($this->error)) {
+            $properties['error'] = $this->error;
+        }
+
         $wrapper = new \stdClass();
         $collection = new \StdClass();
         $collection->version = $this->getVersion();

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -207,15 +207,7 @@ class Collection
     public function output()
     {
         //$properties = get_object_vars( $this );
-        $properties = array(
-            'version' => $this->getVersion(),
-            'href' => $this->href,
-            'links' => $this->links,
-            'items' => $this->items,
-            'queries' => $this->queries,
-            'template' => $this->template,
-            'error' => $this->error,
-        );
+        $properties = array();
         $properties['version'] = $this->getVersion();
         $properties['href'] = $this->href;
         if (!empty($this->links)) {

--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -103,9 +103,7 @@ class DataObject
         $properties = get_object_vars( $this );
         $object = new \StdClass();
         foreach ($properties as $name => $value) {
-            if (!empty($value)) {
-                $object->$name = $value;
-            }
+            $object->$name = $value;
         }
         return $object;
     }

--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -103,7 +103,9 @@ class DataObject
         $properties = get_object_vars( $this );
         $object = new \StdClass();
         foreach ($properties as $name => $value) {
-            $object->$name = $value;
+            if (!empty($value)) {
+                $object->$name = $value;
+            }
         }
         return $object;
     }

--- a/src/Template.php
+++ b/src/Template.php
@@ -47,7 +47,10 @@ class Template extends DataEditor
         foreach ($objects as &$val) {
             $val = $val->output();
         }
-        return $objects;
+        $wrapper = new \stdClass();
+        $wrapper->data = $objects;
+        return $wrapper;
+
     }
 
     /**

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -29,9 +29,9 @@ class CollectionTest extends PHPUnit_Framework_TestCase
         $collection = $wrapper->collection;
         $this->assertNotEmpty( $collection->version );
         $this->assertEquals( $this->href, $collection->href );
-        $this->assertTrue( is_array( $collection->links ) );
-        $this->assertTrue( is_array( $collection->items ) );
-        $this->assertTrue( is_array( $collection->queries ) );
+        //$this->assertTrue( is_array( $collection->links ) );
+        //$this->assertTrue( is_array( $collection->items ) );
+        //$this->assertTrue( is_array( $collection->queries ) );
         $this->assertNotNull( $collection->template );
         $this->assertNotNull( $collection->error );
     }

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -33,7 +33,8 @@ class TemplateTest extends PHPUnit_Framework_TestCase
                                  ->addData( 'testName2', 'testValue2', 'This is pair 2' )
                                  ->output();
         $this->assertNotEmpty( $output );
-        $this->assertCount( 2, $output );
+        $this->assertNotEmpty( $output->data );
+        $this->assertCount( 2, $output->data );
     }
 
     public function testQuery()


### PR DESCRIPTION
Hello again, I have two small changes I would like to add to the project. 

1. I have updated the library to have the root nodes optionally output depending on whether they have content. In other words, of a "queries" node is empty and contains not data, it will not be output. It was added in order to minimize the size of the JSON objects used in data transfer keeping the data packages small. I have kept with the specification and only made the following root node optional (as is stated in the documentation): links, items, queries, template, error

2. The template object is missing the "data" node and is not correctly implemented as is stated in the documentation: See http://amundsen.com/media-types/collection/examples/#ex-template I have corrected this.

The unit tests have been updated to reflect these changes. Thanks again :)